### PR TITLE
Added 'enable_submodules true' to the 'git deploy_path do' section

### DIFF
--- a/gitorious/recipes/default.rb
+++ b/gitorious/recipes/default.rb
@@ -60,6 +60,7 @@ git deploy_path do
   reference   node[:gitorious][:git][:reference]
   user        gitorious_user
   group       gitorious_user
+  enable_submodules true
   action      :sync
   notifies    :run, "execute[restart_gitorious_webapp]"
 end


### PR DESCRIPTION
Girorious uses some submodules that need to be initialized and updated after cloning the repository.
I added and 'enable_submodules true' line to the 'git deploy_path do' block in the Gitorious recipe so this is done by chef.
