### PR TITLE
It is necessary for the database and database user to exist 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ For installing Gitorious in latest Debian stable using Opscode Chef for a comple
     wget -O /etc/chef/solo.rb https://gist.github.com/raw/847256/chef-gitorious-etc-solo.rb
     wget -O /root/chef-solo/node.json https://gist.github.com/raw/847256/chef-gitorious-node-debian.json
 
-First review the settings under /root/chef-solo/node.json. TODO: currently GMail is not supported as smtp relay server. Then procede with:
+First review the settings under /root/chef-solo/node.json.
+If necessary create the gitorious database and database user in mysql.
+TODO: currently GMail is not supported as smtp relay server. Then procede with:
 
     cd /root/chef-solo
     git clone git://github.com/rosenfeld/gitorious-cookbooks.git cookbooks

--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@ For installing Gitorious in latest Debian stable using Opscode Chef for a comple
     wget -O /root/chef-solo/node.json https://gist.github.com/raw/847256/chef-gitorious-node-debian.json
 
 First review the settings under /root/chef-solo/node.json.
+
+gitorious:host must be set to the host name you will be accessing gitorious through otherwise you will get:
+"ActionController::InvalidAuthenticityToken occurred in sessions#create:" when you try to login.
+
 If necessary create the gitorious database and database user in mysql.
-TODO: currently GMail is not supported as smtp relay server. Then procede with:
+TODO: currently GMail is not supported as smtp relay server.
+
+Then procede with:
 
     cd /root/chef-solo
     git clone git://github.com/rosenfeld/gitorious-cookbooks.git cookbooks


### PR DESCRIPTION
before continuing through the installation instructions as they are not created automatically.
Otherwise the install fails much later complaining about access being denied.
