### PR TITLE
Deal with failure when git-daemon fails to start due to bundle failing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ If for some reason apache is not listening in port 443 after install, please res
     invoke-rc.d apache2 restart
 
 I have no idea why this happened to me once...
+
+If git-daemon fails to start causing chef-solo to fail during the install:
+
+    sudo su git
+    cd /var/www/gitorious/script
+    bundle install
+    exit # logout of git user
+    chef-solo


### PR DESCRIPTION
For some reason which bundles are visible depends on which user is running things even if the install is done as root and so it may be necessary to do bundle install as the git user as well. Oh for a proper package management system like apt-get.
